### PR TITLE
change to single seed of RNG in init()

### DIFF
--- a/montecarlo.go
+++ b/montecarlo.go
@@ -8,14 +8,16 @@ import (
 	"time"
 )
 
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
 func GetPi(samples int) float64 {
 	var inside int = 0
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	for i := 0; i < samples; i++ {
-		r.Seed(time.Now().UnixNano())
-		x := r.Float64()
-		y := r.Float64()
+		x := rand.Float64()
+		y := rand.Float64()
 		if (x*x + y*y) < 1 {
 			inside++
 		}
@@ -38,11 +40,9 @@ func GetPiMulti(samples int) float64 {
 			var pi float64
 			var inside int = 0
 			var threadSamples = samples / NCPU
-			r := rand.New(rand.NewSource(time.Now().UnixNano()))
 			for i := 0; i < threadSamples; i++ {
-				r.Seed(time.Now().UnixNano())
-				x := r.Float64()
-				y := r.Float64()
+				x := rand.Float64()
+				y := rand.Float64()
 				if (x*x + y*y) < 1 {
 					inside++
 				}

--- a/montecarlo.go
+++ b/montecarlo.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/rand"
 	"runtime"
-	"sync"
 	"time"
 )
 
@@ -31,12 +30,9 @@ func GetPiMulti(samples int) float64 {
 	runtime.GOMAXPROCS(NCPU)
 
 	results := make(chan float64, NCPU)
-	wg := sync.WaitGroup{}
 
 	for j := 0; j < NCPU; j++ {
 		go func() {
-			wg.Add(1)
-			defer wg.Done()
 			var pi float64
 			var inside int = 0
 			var threadSamples = samples / NCPU
@@ -52,7 +48,6 @@ func GetPiMulti(samples int) float64 {
 		}()
 	}
 
-	wg.Wait()
 	var piTotal float64
 	for t := 0; t < NCPU; t++ {
 		piTotal += <-results


### PR DESCRIPTION
Having all the extraneous calls to Seed() causes almost a 5x performance loss in benchmarks on my 2011 iMac ( 4 cores of Core i5)
rand.Seed() should be called once (often placed in init())

Original version:
 go test -bench .
testing: warning: no tests to run
PASS
BenchmarkGetPi         1    12959684666 ns/op
BenchmarkGetPiMulti        1    4497506505 ns/op
testing: BenchmarkGetPiMulti left GOMAXPROCS set to 4
ok      github.com/billhathaway/go-parallelism-monte-carlo-demo 17.467s

new version:
go test -bench .
testing: warning: no tests to run
PASS
BenchmarkGetPi        20      68930991 ns/op
BenchmarkGetPiMulti        3     354690543 ns/op
testing: BenchmarkGetPiMulti left GOMAXPROCS set to 4
ok      github.com/billhathaway/go-parallelism-monte-carlo-demo 3.587s
